### PR TITLE
Add xref to BFO/RO ID for part_of

### DIFF
--- a/ontologies/dicty_anatomy.obo
+++ b/ontologies/dicty_anatomy.obo
@@ -1206,5 +1206,6 @@ name: develops_from
 [Typedef]
 id: part_of
 name: part of
+xref: BFO:0000050
 is_transitive: true
 


### PR DESCRIPTION
This ensures that DDANAT is compatible with other OBO ontologies.
See: https://github.com/EBISPOT/OLS/issues/11#issuecomment-145927289