### PR TITLE
Add xrefs to relations

### DIFF
--- a/ontologies/dicty_anatomy.obo
+++ b/ontologies/dicty_anatomy.obo
@@ -1172,9 +1172,10 @@ is_a: DDANAT:0010001 ! Dictyostelium discoideum anatomical structure
 [Typedef]
 id: develops_from
 name: develops_from
+xref: RO:0002202
 
 [Typedef]
 id: part_of
 name: part of
 is_transitive: true
-
+xref: BFO:0000050


### PR DESCRIPTION
Adding these xrefs will allow these relations to have standard OBO IRIs when the file is converted to OWL. Currently when DDANAT is imported into GO, duplicate 'part of' and 'develops from' relations are being created.