### PR TITLE
fix/annotation typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/import/data/stockcenter/strain_phenotype.tsv
+++ b/import/data/stockcenter/strain_phenotype.tsv
@@ -893,7 +893,7 @@ DBS0236573	wild type			16571632	act-GFP-mybE develops normally [strain ID: 1608,
 DBS0236573	aberrant prestalk cell differentiation			16571632	mybE- expresses mybE and mrrA in the upper cup but not in the lower cup
 DBS0236177	decreased cell-substrate adhesion		reflection interference contrast microscopy	9230077	
 DBS0236179	aberrant cytokinesis	in suspension	nuclei count	9230077	majority of cells has 2-4 nuclei
-DBS0236179	decreased cell-cell adhesion	in the absense of EDTA	agglutination assay	9230077	vegetative cells
+DBS0236179	decreased cell-cell adhesion	in the absence of EDTA	agglutination assay	9230077	vegetative cells
 DBS0235922	decreased gene expression			16282589	the Skipper retrotransposon was  upregulated in a drnA knock-out strain
 DBS0236540	abolished vegetative growth	in suspension		11719559	Triple mutant rtoA/abcG2/abcG18 does not grow is suspension [strain IDs: 1453, parent: AX4]
 DBS0236540	decreased growth rate			11719559	Triple mutant rtoA/abcG2/abcG18 has decreased growth rate in liquid medium on solid sufaces [strain IDs: 1453, parent: AX4]
@@ -1354,7 +1354,7 @@ DBS0236178	decreased phagocytosis		uptake of yeast particles	9230077	10% that of
 DBS0236178	aberrant mitotic actomyosin contractile ring contraction			22826231	in talA- cells, the cleavage furrow was broader than in wt cells
 DBS0236178	decreased uropod retraction			22826231	in migrating talA- cells, formation of a long, thin tail, often as long as the entire cell; rescued by knocking out sibA
 DBS0236180	aberrant cytokinesis	in suspension	nuclei count	9230077	majority of cells has 2-4 nuclei
-DBS0236180	decreased cell-cell adhesion	in the absense of EDTA	agglutination assay	9230077	vegetative cells
+DBS0236180	decreased cell-cell adhesion	in the absence of EDTA	agglutination assay	9230077	vegetative cells
 DBS0236180	decreased growth rate	in bacterial suspension		9230077	with E. coli B/r
 DBS0236180	decreased phagocytosis		uptake of yeast particles	9230077	10% that of wild type
 DBS0236180	decreased cell-substrate adhesion		reflection interference contrast microscopy	9230077	

--- a/import/data/stockcenter/strain_strain.tsv
+++ b/import/data/stockcenter/strain_strain.tsv
@@ -7069,7 +7069,7 @@ DBS0351367	myoB-/[act15]:myoB(S332A)	Dictyostelium discoideum	myoB with S332A su
 DBS0351459	rasD-/AX3	Dictyostelium discoideum	rasD null mutant in AX3
 DBS0351441	HL73/HL203	Dictyostelium discoideum	heterozygote diploid tester strain; Parents: HL24(DBS0236219), HL203
 DBS0351453	HL208/XP99	Dictyostelium discoideum	heterozygote diploid tester strain; Parents: HL208 and XP99(DBS0237086)
-DBS0351471	AX4	Dictyostelium discoideum	AX4 strain from the Thompson lab that is the parent of GWDI strains. A different isolate of that strain is being sequenced, <a href="http://dictybase.org/db/cgi-bin/dictyBase/phenotype/strain_and_phenotype_details.pl?genotype_id=2083">   AX4</a>
+DBS0351471	AX4	Dictyostelium discoideum	AX4 strain from the Thompson lab that is the parent of GWDI strains. A different isolate of that strain is being sequenced
 DBS0351500	tipB-	Dictyostelium discoideum	tipB REMI mutant
 DBS0351520	AK1334	Dictyostelium discoideum	REMI insertion between two genes, nip7 and DDB_G0271574; note that it is unclear if this mutation has direct impact on any of the adjacent genes.
 DBS0351642	acaA-/acgA-/acrA-/[act15]:pkaC:HA	Dictyostelium discoideum	pkaC overexpression under control of act15 promoter in adenylate-cyclase triple-null


### PR DESCRIPTION
- fix: fix the typos in the phenotype annotation file
- ignore those pesky MacOS file
- fix: remove HTML markdup from AX4 strain
